### PR TITLE
feat: add TDF-style elevation profile component (#3)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import StatCard from "@/components/StatCard";
 import DashboardClient from "@/components/DashboardClient";
-import { mockActivities, monthlySummary } from "@/lib/mockData";
+import ElevationProfile from "@/components/ElevationProfile";
+import { mockActivities, monthlySummary, mockTrackData } from "@/lib/mockData";
 
 export default function DashboardPage() {
   return (
@@ -29,6 +30,15 @@ export default function DashboardPage() {
           value={monthlySummary.avgSpeed}
           unit="km/h"
           icon="⚡"
+        />
+      </div>
+
+      {/* Route & Elevation Profile */}
+      <div>
+        <h2 className="text-lg font-semibold text-white mb-3">Route &amp; Elevation Profile</h2>
+        <ElevationProfile
+          trackPoints={mockTrackData}
+          routeName="Mountain Pass Challenge"
         />
       </div>
 

--- a/src/components/ElevationProfile.tsx
+++ b/src/components/ElevationProfile.tsx
@@ -1,0 +1,521 @@
+'use client';
+
+import { useState, useCallback, useMemo, useId } from 'react';
+
+export interface TrackPoint {
+  distance: number; // km from start
+  elevation: number; // meters above sea level
+  lat?: number;
+  lng?: number;
+}
+
+interface ElevationProfileProps {
+  trackPoints: TrackPoint[];
+  routeName?: string;
+  className?: string;
+}
+
+// SVG canvas dimensions
+const VIEW_W = 900;
+const VIEW_H = 280;
+const PAD = { top: 44, right: 28, bottom: 48, left: 68 };
+const CHART_W = VIEW_W - PAD.left - PAD.right;
+const CHART_H = VIEW_H - PAD.top - PAD.bottom;
+
+/** Catmull-Rom spline → SVG cubic bezier path string */
+function catmullRomPath(pts: { x: number; y: number }[]): string {
+  if (pts.length < 2) return '';
+  const d: string[] = [`M ${pts[0].x.toFixed(1)} ${pts[0].y.toFixed(1)}`];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[Math.max(i - 1, 0)];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[Math.min(i + 2, pts.length - 1)];
+    const cp1x = p1.x + (p2.x - p0.x) / 6;
+    const cp1y = p1.y + (p2.y - p0.y) / 6;
+    const cp2x = p2.x - (p3.x - p1.x) / 6;
+    const cp2y = p2.y - (p3.y - p1.y) / 6;
+    d.push(
+      `C ${cp1x.toFixed(1)} ${cp1y.toFixed(1)}, ${cp2x.toFixed(1)} ${cp2y.toFixed(1)}, ${p2.x.toFixed(1)} ${p2.y.toFixed(1)}`
+    );
+  }
+  return d.join(' ');
+}
+
+export default function ElevationProfile({
+  trackPoints,
+  routeName = 'Route Profile',
+  className = '',
+}: ElevationProfileProps) {
+  const uid = useId().replace(/:/g, '');
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  /* ── Derived statistics ── */
+  const stats = useMemo(() => {
+    if (trackPoints.length === 0) return null;
+    const elevs = trackPoints.map((p) => p.elevation);
+    const maxElev = Math.max(...elevs);
+    const minElev = Math.min(...elevs);
+    const maxDist = trackPoints[trackPoints.length - 1].distance;
+    let totalGain = 0;
+    for (let i = 1; i < trackPoints.length; i++) {
+      const diff = trackPoints[i].elevation - trackPoints[i - 1].elevation;
+      if (diff > 0) totalGain += diff;
+    }
+    const summitIdx = elevs.indexOf(maxElev);
+    return { maxElev, minElev, maxDist, totalGain: Math.round(totalGain), summitIdx };
+  }, [trackPoints]);
+
+  /* ── Map track points → SVG coordinates ── */
+  const svgPts = useMemo(() => {
+    if (!stats) return [];
+    const { maxElev, minElev, maxDist } = stats;
+    const span = maxElev - minElev;
+    const paddedMin = minElev - span * 0.08;
+    const paddedMax = maxElev + span * 0.12;
+    const elevSpan = paddedMax - paddedMin;
+    return trackPoints.map((p) => ({
+      x: PAD.left + (p.distance / maxDist) * CHART_W,
+      y: PAD.top + CHART_H - ((p.elevation - paddedMin) / elevSpan) * CHART_H,
+    }));
+  }, [trackPoints, stats]);
+
+  /* ── Y-axis ticks ── */
+  const yTicks = useMemo(() => {
+    if (!stats) return [];
+    const { maxElev, minElev } = stats;
+    const span = maxElev - minElev;
+    const paddedMin = minElev - span * 0.08;
+    const paddedMax = maxElev + span * 0.12;
+    const elevSpan = paddedMax - paddedMin;
+    const interval = Math.ceil(span / 4 / 100) * 100 || 100;
+    const start = Math.ceil(paddedMin / interval) * interval;
+    const ticks: { value: number; y: number }[] = [];
+    for (let v = start; v <= paddedMax + 1; v += interval) {
+      ticks.push({
+        value: v,
+        y: PAD.top + CHART_H - ((v - paddedMin) / elevSpan) * CHART_H,
+      });
+    }
+    return ticks;
+  }, [stats]);
+
+  /* ── X-axis ticks ── */
+  const xTicks = useMemo(() => {
+    if (!stats) return [];
+    const { maxDist } = stats;
+    const interval = maxDist > 50 ? 10 : maxDist > 25 ? 5 : 2;
+    const ticks: { value: number; x: number }[] = [];
+    for (let d = 0; d <= maxDist; d += interval) {
+      ticks.push({ value: d, x: PAD.left + (d / maxDist) * CHART_W });
+    }
+    const last = ticks[ticks.length - 1];
+    if (last.value < maxDist - interval * 0.3) {
+      ticks.push({ value: Math.round(maxDist * 10) / 10, x: PAD.left + CHART_W });
+    }
+    return ticks;
+  }, [stats]);
+
+  const smoothPath = useMemo(() => catmullRomPath(svgPts), [svgPts]);
+
+  const fillPath = useMemo(() => {
+    if (svgPts.length === 0) return '';
+    const bottom = PAD.top + CHART_H;
+    const last = svgPts[svgPts.length - 1];
+    return `${smoothPath} L ${last.x.toFixed(1)} ${bottom} L ${PAD.left} ${bottom} Z`;
+  }, [smoothPath, svgPts]);
+
+  /* ── Hover interaction ── */
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (!stats) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const scaleX = VIEW_W / rect.width;
+      const chartX = (e.clientX - rect.left) * scaleX - PAD.left;
+      if (chartX < 0 || chartX > CHART_W) {
+        setHoverIdx(null);
+        return;
+      }
+      const dist = (chartX / CHART_W) * stats.maxDist;
+      let closest = 0;
+      let minDiff = Infinity;
+      trackPoints.forEach((p, i) => {
+        const diff = Math.abs(p.distance - dist);
+        if (diff < minDiff) {
+          minDiff = diff;
+          closest = i;
+        }
+      });
+      setHoverIdx(closest);
+    },
+    [stats, trackPoints]
+  );
+
+  if (!stats || trackPoints.length === 0) {
+    return (
+      <div className={`bg-gray-900 rounded-xl p-6 ${className}`}>
+        <p className="text-gray-500 text-sm">No track data available</p>
+      </div>
+    );
+  }
+
+  const hoverPt = hoverIdx !== null ? trackPoints[hoverIdx] : null;
+  const hoverSvg = hoverIdx !== null ? svgPts[hoverIdx] : null;
+  const summitSvg = svgPts[stats.summitIdx];
+
+  // IDs scoped per instance to avoid collisions when multiple charts are rendered
+  const gradFillId = `elevFill-${uid}`;
+  const gradStrokeId = `elevStroke-${uid}`;
+  const glowId = `glow-${uid}`;
+  const clipId = `reveal-${uid}`;
+
+  return (
+    <div className={`bg-[#0b0b18] rounded-xl overflow-hidden border border-white/8 ${className}`}>
+      {/* ── Header bar ── */}
+      <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3 border-b border-white/8">
+        <div className="flex items-center gap-3">
+          <div className="w-1 h-5 bg-[#FFDB00] rounded-full" />
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-gray-500 font-semibold">
+              Elevation Profile
+            </p>
+            <h3 className="text-sm font-bold text-white leading-tight">{routeName}</h3>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-5">
+          <div className="text-right">
+            <p className="text-[10px] text-gray-500 uppercase tracking-wider">Distance</p>
+            <p className="text-sm font-bold text-white">
+              {stats.maxDist.toFixed(1)}{' '}
+              <span className="text-gray-400 font-normal text-xs">km</span>
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-[10px] text-gray-500 uppercase tracking-wider">Total Climb</p>
+            <p className="text-sm font-bold text-[#FFDB00]">
+              +{stats.totalGain.toLocaleString()}{' '}
+              <span className="text-gray-400 font-normal text-xs">m</span>
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-[10px] text-gray-500 uppercase tracking-wider">Summit</p>
+            <p className="text-sm font-bold text-white">
+              {stats.maxElev.toLocaleString()}{' '}
+              <span className="text-gray-400 font-normal text-xs">m</span>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* ── SVG Chart ── */}
+      <div className="px-1 pb-2 pt-1">
+        <svg
+          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+          className="w-full"
+          style={{ height: 'auto', cursor: 'crosshair' }}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={() => setHoverIdx(null)}
+          aria-label={`Elevation profile for ${routeName}`}
+          role="img"
+        >
+          <defs>
+            {/* Terrain fill gradient */}
+            <linearGradient id={gradFillId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#FFDB00" stopOpacity="0.45" />
+              <stop offset="55%" stopColor="#FF7700" stopOpacity="0.18" />
+              <stop offset="100%" stopColor="#0b0b18" stopOpacity="0.0" />
+            </linearGradient>
+
+            {/* Stroke gradient (left→right warm sweep) */}
+            <linearGradient id={gradStrokeId} x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stopColor="#FFE449" />
+              <stop offset="55%" stopColor="#FFAB00" />
+              <stop offset="100%" stopColor="#FF6B00" />
+            </linearGradient>
+
+            {/* Glow filter for the path */}
+            <filter id={glowId} x="-5%" y="-30%" width="110%" height="160%">
+              <feGaussianBlur in="SourceGraphic" stdDeviation="2.5" result="blur" />
+              <feMerge>
+                <feMergeNode in="blur" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+
+            {/* Animated clip that reveals the chart left→right */}
+            <clipPath id={clipId}>
+              <rect x={PAD.left} y={0} height={VIEW_H} width={0}>
+                <animate
+                  attributeName="width"
+                  from="0"
+                  to={CHART_W}
+                  dur="1.6s"
+                  begin="0.1s"
+                  fill="freeze"
+                  calcMode="spline"
+                  keyTimes="0;1"
+                  keySplines="0.22 0.61 0.36 1"
+                />
+              </rect>
+            </clipPath>
+          </defs>
+
+          {/* Dark background */}
+          <rect width={VIEW_W} height={VIEW_H} fill="#0b0b18" />
+
+          {/* Y grid lines + labels */}
+          {yTicks.map(({ value, y }) => (
+            <g key={value}>
+              <line
+                x1={PAD.left}
+                y1={y}
+                x2={PAD.left + CHART_W}
+                y2={y}
+                stroke="rgba(255,255,255,0.06)"
+                strokeWidth="1"
+              />
+              <text
+                x={PAD.left - 8}
+                y={y}
+                textAnchor="end"
+                dominantBaseline="middle"
+                fill="rgba(255,255,255,0.38)"
+                fontSize="10"
+                fontFamily="'Courier New', monospace"
+              >
+                {value}
+              </text>
+            </g>
+          ))}
+
+          {/* X axis baseline */}
+          <line
+            x1={PAD.left}
+            y1={PAD.top + CHART_H}
+            x2={PAD.left + CHART_W}
+            y2={PAD.top + CHART_H}
+            stroke="rgba(255,255,255,0.15)"
+            strokeWidth="1"
+          />
+
+          {/* X ticks + labels */}
+          {xTicks.map(({ value, x }) => (
+            <g key={value}>
+              <line
+                x1={x}
+                y1={PAD.top + CHART_H}
+                x2={x}
+                y2={PAD.top + CHART_H + 5}
+                stroke="rgba(255,255,255,0.25)"
+                strokeWidth="1"
+              />
+              <text
+                x={x}
+                y={PAD.top + CHART_H + 16}
+                textAnchor="middle"
+                fill="rgba(255,255,255,0.38)"
+                fontSize="10"
+                fontFamily="'Courier New', monospace"
+              >
+                {value}
+              </text>
+            </g>
+          ))}
+
+          {/* Axis labels */}
+          <text
+            x={PAD.left + CHART_W / 2}
+            y={VIEW_H - 5}
+            textAnchor="middle"
+            fill="rgba(255,255,255,0.22)"
+            fontSize="8.5"
+            fontFamily="sans-serif"
+            letterSpacing="2"
+          >
+            DISTANCE (KM)
+          </text>
+          <text
+            x={13}
+            y={PAD.top + CHART_H / 2}
+            textAnchor="middle"
+            fill="rgba(255,255,255,0.22)"
+            fontSize="8.5"
+            fontFamily="sans-serif"
+            letterSpacing="2"
+            transform={`rotate(-90, 13, ${PAD.top + CHART_H / 2})`}
+          >
+            ELEVATION (M)
+          </text>
+
+          {/* ── Animated terrain ── */}
+          <g clipPath={`url(#${clipId})`}>
+            {/* Filled terrain area */}
+            <path d={fillPath} fill={`url(#${gradFillId})`} />
+
+            {/* Elevation line with glow */}
+            <path
+              d={smoothPath}
+              fill="none"
+              stroke={`url(#${gradStrokeId})`}
+              strokeWidth="2.5"
+              strokeLinejoin="round"
+              filter={`url(#${glowId})`}
+            />
+          </g>
+
+          {/* ── Summit marker (HC triangle) ── */}
+          {summitSvg && (
+            <g>
+              <line
+                x1={summitSvg.x}
+                y1={summitSvg.y - 2}
+                x2={summitSvg.x}
+                y2={PAD.top + CHART_H}
+                stroke="rgba(255,219,0,0.25)"
+                strokeWidth="1"
+                strokeDasharray="4 3"
+              />
+              {/* Triangle peak */}
+              <polygon
+                points={`${summitSvg.x},${summitSvg.y - 20} ${summitSvg.x - 8},${summitSvg.y - 5} ${summitSvg.x + 8},${summitSvg.y - 5}`}
+                fill="#FFDB00"
+              />
+              {/* "HC" label */}
+              <text
+                x={summitSvg.x}
+                y={summitSvg.y - 25}
+                textAnchor="middle"
+                fill="#FFDB00"
+                fontSize="9"
+                fontWeight="800"
+                fontFamily="sans-serif"
+                letterSpacing="0.5"
+              >
+                HC
+              </text>
+              {/* Elevation value */}
+              <text
+                x={summitSvg.x}
+                y={summitSvg.y - 36}
+                textAnchor="middle"
+                fill="rgba(255,219,0,0.85)"
+                fontSize="10"
+                fontWeight="bold"
+                fontFamily="'Courier New', monospace"
+              >
+                {stats.maxElev}m
+              </text>
+            </g>
+          )}
+
+          {/* ── Start marker ── */}
+          {svgPts.length > 0 && (
+            <g>
+              <circle cx={svgPts[0].x} cy={svgPts[0].y} r="5" fill="#22c55e" />
+              <text
+                x={svgPts[0].x + 9}
+                y={svgPts[0].y - 3}
+                fill="#22c55e"
+                fontSize="9"
+                fontWeight="700"
+                fontFamily="sans-serif"
+                letterSpacing="0.5"
+              >
+                START
+              </text>
+            </g>
+          )}
+
+          {/* ── Finish marker ── */}
+          {svgPts.length > 1 && (
+            <g>
+              <circle
+                cx={svgPts[svgPts.length - 1].x}
+                cy={svgPts[svgPts.length - 1].y}
+                r="5"
+                fill="#f87171"
+              />
+              <text
+                x={svgPts[svgPts.length - 1].x - 9}
+                y={svgPts[svgPts.length - 1].y - 3}
+                textAnchor="end"
+                fill="#f87171"
+                fontSize="9"
+                fontWeight="700"
+                fontFamily="sans-serif"
+                letterSpacing="0.5"
+              >
+                FINISH
+              </text>
+            </g>
+          )}
+
+          {/* ── Hover crosshair + tooltip ── */}
+          {hoverPt && hoverSvg && (
+            <g>
+              {/* Vertical crosshair */}
+              <line
+                x1={hoverSvg.x}
+                y1={PAD.top}
+                x2={hoverSvg.x}
+                y2={PAD.top + CHART_H}
+                stroke="rgba(255,255,255,0.35)"
+                strokeWidth="1"
+                strokeDasharray="4 3"
+              />
+              {/* Data point circle */}
+              <circle
+                cx={hoverSvg.x}
+                cy={hoverSvg.y}
+                r="5"
+                fill="#FFDB00"
+                stroke="white"
+                strokeWidth="1.5"
+              />
+              {/* Tooltip box */}
+              {(() => {
+                const flip = hoverSvg.x > PAD.left + CHART_W * 0.72;
+                const tx = flip ? hoverSvg.x - 94 : hoverSvg.x + 10;
+                const ty = Math.max(PAD.top + 4, hoverSvg.y - 42);
+                return (
+                  <g>
+                    <rect
+                      x={tx}
+                      y={ty}
+                      width={84}
+                      height={38}
+                      rx="4"
+                      fill="rgba(5,5,20,0.92)"
+                      stroke="rgba(255,219,0,0.45)"
+                      strokeWidth="1"
+                    />
+                    <text
+                      x={tx + 8}
+                      y={ty + 14}
+                      fill="rgba(255,255,255,0.55)"
+                      fontSize="9"
+                      fontFamily="'Courier New', monospace"
+                    >
+                      {hoverPt.distance.toFixed(1)} km
+                    </text>
+                    <text
+                      x={tx + 8}
+                      y={ty + 27}
+                      fill="#FFDB00"
+                      fontSize="12"
+                      fontWeight="bold"
+                      fontFamily="'Courier New', monospace"
+                    >
+                      {Math.round(hoverPt.elevation)} m
+                    </text>
+                  </g>
+                );
+              })()}
+            </g>
+          )}
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ElevationProfile.tsx
+++ b/src/components/ElevationProfile.tsx
@@ -1,13 +1,9 @@
 'use client';
 
 import { useState, useCallback, useMemo, useId } from 'react';
+import { TrackPoint } from '@/lib/types';
 
-export interface TrackPoint {
-  distance: number; // km from start
-  elevation: number; // meters above sea level
-  lat?: number;
-  lng?: number;
-}
+export type { TrackPoint };
 
 interface ElevationProfileProps {
   trackPoints: TrackPoint[];
@@ -21,6 +17,8 @@ const VIEW_H = 280;
 const PAD = { top: 44, right: 28, bottom: 48, left: 68 };
 const CHART_W = VIEW_W - PAD.left - PAD.right;
 const CHART_H = VIEW_H - PAD.top - PAD.bottom;
+// Minimum vertical span to avoid divide-by-zero on flat profiles
+const MIN_ELEV_SPAN = 10;
 
 /** Catmull-Rom spline → SVG cubic bezier path string */
 function catmullRomPath(pts: { x: number; y: number }[]): string {
@@ -42,6 +40,22 @@ function catmullRomPath(pts: { x: number; y: number }[]): string {
   return d.join(' ');
 }
 
+/** Binary search: index of the element in a sorted array closest to target */
+function binarySearchClosest(arr: number[], target: number): number {
+  if (arr.length === 0) return 0;
+  let lo = 0;
+  let hi = arr.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+  if (lo > 0 && Math.abs(arr[lo - 1] - target) <= Math.abs(arr[lo] - target)) {
+    return lo - 1;
+  }
+  return lo;
+}
+
 export default function ElevationProfile({
   trackPoints,
   routeName = 'Route Profile',
@@ -50,35 +64,55 @@ export default function ElevationProfile({
   const uid = useId().replace(/:/g, '');
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 
-  /* ── Derived statistics ── */
+  /* ── Derived statistics (sorts input by distance defensively) ── */
   const stats = useMemo(() => {
-    if (trackPoints.length === 0) return null;
-    const elevs = trackPoints.map((p) => p.elevation);
+    if (trackPoints.length < 2) return null;
+
+    // Sort a copy so callers don't need to guarantee order
+    const sorted = [...trackPoints].sort((a, b) => a.distance - b.distance);
+    const maxDist = sorted[sorted.length - 1].distance;
+
+    // Guard: a single point at distance 0 (or duplicate distances) makes the X axis degenerate
+    if (maxDist <= 0) return null;
+
+    const elevs = sorted.map((p) => p.elevation);
     const maxElev = Math.max(...elevs);
     const minElev = Math.min(...elevs);
-    const maxDist = trackPoints[trackPoints.length - 1].distance;
+
     let totalGain = 0;
-    for (let i = 1; i < trackPoints.length; i++) {
-      const diff = trackPoints[i].elevation - trackPoints[i - 1].elevation;
+    for (let i = 1; i < sorted.length; i++) {
+      const diff = sorted[i].elevation - sorted[i - 1].elevation;
       if (diff > 0) totalGain += diff;
     }
+
     const summitIdx = elevs.indexOf(maxElev);
-    return { maxElev, minElev, maxDist, totalGain: Math.round(totalGain), summitIdx };
+    const distances = sorted.map((p) => p.distance); // pre-built for binary search
+
+    return {
+      sorted,
+      distances,
+      maxElev,
+      minElev,
+      maxDist,
+      totalGain: Math.round(totalGain),
+      summitIdx,
+    };
   }, [trackPoints]);
 
-  /* ── Map track points → SVG coordinates ── */
+  /* ── Map sorted track points → SVG coordinates ── */
   const svgPts = useMemo(() => {
     if (!stats) return [];
-    const { maxElev, minElev, maxDist } = stats;
+    const { sorted, maxElev, minElev, maxDist } = stats;
     const span = maxElev - minElev;
     const paddedMin = minElev - span * 0.08;
     const paddedMax = maxElev + span * 0.12;
-    const elevSpan = paddedMax - paddedMin;
-    return trackPoints.map((p) => ({
+    // Clamp to MIN_ELEV_SPAN so flat profiles never divide by zero
+    const elevSpan = Math.max(paddedMax - paddedMin, MIN_ELEV_SPAN);
+    return sorted.map((p) => ({
       x: PAD.left + (p.distance / maxDist) * CHART_W,
       y: PAD.top + CHART_H - ((p.elevation - paddedMin) / elevSpan) * CHART_H,
     }));
-  }, [trackPoints, stats]);
+  }, [stats]);
 
   /* ── Y-axis ticks ── */
   const yTicks = useMemo(() => {
@@ -87,7 +121,7 @@ export default function ElevationProfile({
     const span = maxElev - minElev;
     const paddedMin = minElev - span * 0.08;
     const paddedMax = maxElev + span * 0.12;
-    const elevSpan = paddedMax - paddedMin;
+    const elevSpan = Math.max(paddedMax - paddedMin, MIN_ELEV_SPAN);
     const interval = Math.ceil(span / 4 / 100) * 100 || 100;
     const start = Math.ceil(paddedMin / interval) * interval;
     const ticks: { value: number; y: number }[] = [];
@@ -118,14 +152,15 @@ export default function ElevationProfile({
 
   const smoothPath = useMemo(() => catmullRomPath(svgPts), [svgPts]);
 
+  // Require >= 2 SVG points so smoothPath is non-empty before closing the fill shape
   const fillPath = useMemo(() => {
-    if (svgPts.length === 0) return '';
+    if (svgPts.length < 2 || !smoothPath) return '';
     const bottom = PAD.top + CHART_H;
     const last = svgPts[svgPts.length - 1];
     return `${smoothPath} L ${last.x.toFixed(1)} ${bottom} L ${PAD.left} ${bottom} Z`;
   }, [smoothPath, svgPts]);
 
-  /* ── Hover interaction ── */
+  /* ── Hover interaction — O(log n) binary search on sorted distances ── */
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
       if (!stats) return;
@@ -137,21 +172,12 @@ export default function ElevationProfile({
         return;
       }
       const dist = (chartX / CHART_W) * stats.maxDist;
-      let closest = 0;
-      let minDiff = Infinity;
-      trackPoints.forEach((p, i) => {
-        const diff = Math.abs(p.distance - dist);
-        if (diff < minDiff) {
-          minDiff = diff;
-          closest = i;
-        }
-      });
-      setHoverIdx(closest);
+      setHoverIdx(binarySearchClosest(stats.distances, dist));
     },
-    [stats, trackPoints]
+    [stats]
   );
 
-  if (!stats || trackPoints.length === 0) {
+  if (!stats) {
     return (
       <div className={`bg-gray-900 rounded-xl p-6 ${className}`}>
         <p className="text-gray-500 text-sm">No track data available</p>
@@ -159,7 +185,7 @@ export default function ElevationProfile({
     );
   }
 
-  const hoverPt = hoverIdx !== null ? trackPoints[hoverIdx] : null;
+  const hoverPt = hoverIdx !== null ? stats.sorted[hoverIdx] : null;
   const hoverSvg = hoverIdx !== null ? svgPts[hoverIdx] : null;
   const summitSvg = svgPts[stats.summitIdx];
 
@@ -351,17 +377,19 @@ export default function ElevationProfile({
           {/* ── Animated terrain ── */}
           <g clipPath={`url(#${clipId})`}>
             {/* Filled terrain area */}
-            <path d={fillPath} fill={`url(#${gradFillId})`} />
+            {fillPath && <path d={fillPath} fill={`url(#${gradFillId})`} />}
 
             {/* Elevation line with glow */}
-            <path
-              d={smoothPath}
-              fill="none"
-              stroke={`url(#${gradStrokeId})`}
-              strokeWidth="2.5"
-              strokeLinejoin="round"
-              filter={`url(#${glowId})`}
-            />
+            {smoothPath && (
+              <path
+                d={smoothPath}
+                fill="none"
+                stroke={`url(#${gradStrokeId})`}
+                strokeWidth="2.5"
+                strokeLinejoin="round"
+                filter={`url(#${glowId})`}
+              />
+            )}
           </g>
 
           {/* ── Summit marker (HC triangle) ── */}

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -1,9 +1,6 @@
-export interface TrackPoint {
-  distance: number; // km from start
-  elevation: number; // meters above sea level
-  lat?: number;
-  lng?: number;
-}
+import { TrackPoint } from '@/lib/types';
+
+export type { TrackPoint };
 
 // Realistic elevation profile for "Mountain Pass Challenge"
 // A 65.1km alpine stage with ~1450m total elevation gain

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -1,3 +1,82 @@
+export interface TrackPoint {
+  distance: number; // km from start
+  elevation: number; // meters above sea level
+  lat?: number;
+  lng?: number;
+}
+
+// Realistic elevation profile for "Mountain Pass Challenge"
+// A 65.1km alpine stage with ~1450m total elevation gain
+export const mockTrackData: TrackPoint[] = [
+  { distance: 0, elevation: 280 },
+  { distance: 1, elevation: 275 },
+  { distance: 2, elevation: 265 },
+  { distance: 3, elevation: 270 },
+  { distance: 4, elevation: 258 },
+  { distance: 5, elevation: 252 },
+  { distance: 6, elevation: 245 },
+  { distance: 7, elevation: 238 },
+  { distance: 8, elevation: 228 },
+  { distance: 9, elevation: 218 },
+  { distance: 10, elevation: 210 },
+  { distance: 11, elevation: 205 },
+  { distance: 12, elevation: 200 },
+  { distance: 13, elevation: 194 },
+  { distance: 14, elevation: 188 },
+  { distance: 15, elevation: 182 },
+  { distance: 16, elevation: 178 },
+  { distance: 17, elevation: 174 },
+  { distance: 18, elevation: 172 },
+  { distance: 19, elevation: 185 },
+  { distance: 20, elevation: 212 },
+  { distance: 21, elevation: 252 },
+  { distance: 22, elevation: 300 },
+  { distance: 23, elevation: 358 },
+  { distance: 24, elevation: 425 },
+  { distance: 25, elevation: 498 },
+  { distance: 26, elevation: 578 },
+  { distance: 27, elevation: 660 },
+  { distance: 28, elevation: 748 },
+  { distance: 29, elevation: 838 },
+  { distance: 30, elevation: 928 },
+  { distance: 31, elevation: 1015 },
+  { distance: 32, elevation: 1098 },
+  { distance: 33, elevation: 1175 },
+  { distance: 34, elevation: 1245 },
+  { distance: 35, elevation: 1310 },
+  { distance: 36, elevation: 1368 },
+  { distance: 37, elevation: 1418 },
+  { distance: 38, elevation: 1460 },
+  { distance: 39, elevation: 1495 },
+  { distance: 40, elevation: 1522 },
+  { distance: 41, elevation: 1540 },
+  { distance: 42, elevation: 1550 },
+  { distance: 43, elevation: 1555 },
+  { distance: 44, elevation: 1548 },
+  { distance: 45, elevation: 1532 },
+  { distance: 46, elevation: 1510 },
+  { distance: 47, elevation: 1484 },
+  { distance: 48, elevation: 1452 },
+  { distance: 49, elevation: 1418 },
+  { distance: 50, elevation: 1382 },
+  { distance: 51, elevation: 1348 },
+  { distance: 52, elevation: 1318 },
+  { distance: 53, elevation: 1292 },
+  { distance: 54, elevation: 1272 },
+  { distance: 55, elevation: 1260 },
+  { distance: 56, elevation: 1255 },
+  { distance: 57, elevation: 1252 },
+  { distance: 58, elevation: 1258 },
+  { distance: 59, elevation: 1268 },
+  { distance: 60, elevation: 1278 },
+  { distance: 61, elevation: 1286 },
+  { distance: 62, elevation: 1294 },
+  { distance: 63, elevation: 1302 },
+  { distance: 64, elevation: 1310 },
+  { distance: 65, elevation: 1316 },
+  { distance: 65.1, elevation: 1318 },
+];
+
 export interface Activity {
   id: string;
   date: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,6 @@
+export interface TrackPoint {
+  distance: number; // km from start
+  elevation: number; // meters above sea level
+  lat?: number;
+  lng?: number;
+}


### PR DESCRIPTION
## Summary

Implements the Route & Elevation Profile widget requested in issue #3.

- **New `ElevationProfile` client component** (`src/components/ElevationProfile.tsx`) — a standalone, strictly-encapsulated React Client Component with a clean `TrackPoint[]` props interface (`distance`, `elevation`, `lat?`, `lng?`).
- **Pure SVG rendering** using a smooth Catmull-Rom spline, warm yellow-orange gradient fill, and a soft glow filter — visual style inspired by Tour de France broadcast panels.
- **Left-to-right animated reveal** via native SVG `<animate>` (no JS animation loop, no extra dependencies).
- **Interactive hover crosshair** with a tooltip showing distance (km) and elevation (m) at the cursor position.
- **HC summit triangle** marker at the highest elevation point, with elevation label.
- **Start / Finish dot** markers at both ends of the route.
- **Auto-scaled axes**: Y ticks rounded to 100m intervals, X ticks every 10 km (or 5/2 km for shorter routes), plus axis labels.
- **Header stats bar**: Total Distance, Total Climb (+m), Summit elevation.
- **Mock track data** added to `mockData.ts`: 67-point alpine stage profile (65.1 km, ~1450 m elevation gain) for "Mountain Pass Challenge".
- Component integrated into the main dashboard page below the stat cards.

## Test plan

- [x] `tsc --noEmit` — no type errors
- [x] ESLint — no warnings
- [x] `next build` — compiles and generates static pages successfully
- [ ] Visual review: elevation profile renders with animation, gradient fill, summit marker, start/finish labels, and responsive hover tooltip

Closes #3